### PR TITLE
Fix: Ensure ZTIGather.xml is copied to the share for PSD

### DIFF
--- a/Documentation/InstallationGuide.md
+++ b/Documentation/InstallationGuide.md
@@ -1,0 +1,123 @@
+# PowerShell Deployment (PSD) Installation Guide
+
+This guide provides step-by-step instructions for installing and configuring the PowerShell Deployment (PSD) solution, which enhances Microsoft Deployment Toolkit (MDT) with PowerShell-driven capabilities.
+
+## 1. Prerequisites
+
+Before installing PSD, ensure your environment meets the following prerequisites:
+
+*   **Windows Assessment and Deployment Kit (ADK):**
+    *   A compatible version of the Windows ADK must be installed. `Install-PSD.ps1` checks for a minimum ADK build (typically 17763 or higher, see script for exact version).
+    *   **Windows PE (WinPE) Add-on:** The WinPE add-on for the installed ADK version is also required.
+*   **Microsoft Deployment Toolkit (MDT):**
+    *   A compatible version of MDT must be installed. `Install-PSD.ps1` will check for its presence.
+*   **PowerShell:**
+    *   PowerShell 5.1 or later is recommended for both the server running MDT and for client execution during deployment.
+*   **Administrative Privileges:** You will need local administrator privileges on the MDT server to run `Install-PSD.ps1` and configure the deployment share.
+
+## 2. Obtaining PSD Source Files
+
+Download or clone the PSD project files from the official repository (e.g., GitHub). This will typically include:
+*   `Install-PSD.ps1` (the main installer script)
+*   The `Scripts` directory (containing core PSD scripts and modules)
+*   The `Templates` directory (PSD-specific unattend.xml templates, etc.)
+*   The `INIFiles` directory (default `Bootstrap.ini` and `CustomSettings.ini`)
+*   The `PSDResources` directory (branding, tools, prestart files)
+*   The `Branding` directory (source for some branding files)
+*   The `Plugins` directory
+
+Place these files in a known location on your MDT server from where you will run the installation.
+
+## 3. Running the Installer (`Install-PSD.ps1`)
+
+`Install-PSD.ps1` automates the creation of a new PSD-enabled deployment share or upgrades an existing one.
+
+1.  **Open PowerShell as Administrator:** On your MDT server, open an elevated PowerShell console.
+2.  **Navigate to Source Directory:** Change to the directory where you placed the PSD source files, specifically where `Install-PSD.ps1` is located.
+3.  **Execute `Install-PSD.ps1`:**
+
+    *   **Parameters:**
+        *   `-psDeploymentFolder <PhysicalPath>`: **Mandatory.** The full physical path where the deployment share will be created (e.g., `D:\PSDShare`).
+        *   `-psDeploymentShare <ShareName>`: **Mandatory.** The name for the network share (e.g., `PSDShare$`). It's recommended to make it a hidden share by appending `$`.
+        *   `[-Upgrade]`: **Optional.** Switch parameter. If specified, the script attempts to upgrade an existing deployment share at the given path and share name.
+        *   `[-Silent]`: **Optional.** Switch parameter. If specified, the script will bypass interactive prompts for `Bootstrap.ini` and `CustomSettings.ini` settings and will instead use the default files from the `INIFiles` source directory.
+
+    *   **Example (New Installation - Interactive):**
+        ```powershell
+        .\Install-PSD.ps1 -psDeploymentFolder D:\MDTProduction -psDeploymentShare MDTProduction$
+        ```
+
+    *   **Example (New Installation - Silent):**
+        ```powershell
+        .\Install-PSD.ps1 -psDeploymentFolder D:\MDTProduction -psDeploymentShare MDTProduction$ -Silent
+        ```
+
+    *   **Example (Upgrade an Existing Share - Usually Interactive):**
+        ```powershell
+        .\Install-PSD.ps1 -psDeploymentFolder D:\MDTProduction -psDeploymentShare MDTProduction$ -Upgrade
+        ```
+
+### 3.1. Interactive Mode Prompts (if `-Silent` is NOT used)
+
+If you run `Install-PSD.ps1` without the `-Silent` switch, you will be prompted to configure initial settings for `Bootstrap.ini` and `CustomSettings.ini`. This helps tailor the deployment share to your environment quickly.
+
+*   **Bootstrap.ini Prompts:**
+    *   **DeployRoot Override:** The network path clients will use to connect (e.g., `\\SERVERNAME\PSDShare$`). Defaults to a path based on the server's name and the share name you provided.
+    *   **UserID, UserDomain, UserPassword:** Credentials for connecting to the deployment share.
+        *   *Warning:* Storing passwords in `Bootstrap.ini` is a security risk. For production, consider domain-joined clients with appropriate share permissions or other secure access methods. You can leave these blank to be prompted in WinPE.
+    *   **SkipBootstrap:** Whether to skip the Bootstrap phase (rarely Yes).
+
+*   **CustomSettings.ini Prompts:**
+    *   **AdminPassword:** Password for the local Administrator account on deployed clients.
+    *   **TimeZone:** The time zone for deployed clients (e.g., "Pacific Standard Time").
+    *   **SkipProductKey:** (Y/N)
+    *   **SkipComputerName:** (Y/N) - If No, prompts in WinPE.
+    *   **SkipDomainMembership:** (Y/N) - If No, prompts in WinPE for domain details.
+    *   **SkipUserData:** (Y/N)
+    *   **SkipLocaleSelection:** (Y/N) - If No, prompts in WinPE.
+    *   **SkipTimeZone:** (Y/N) - If No, uses the TimeZone value set above.
+
+The script will use your answers to generate these INI files in the `Control` folder of your new deployment share.
+
+### 3.2. What `Install-PSD.ps1` Does
+
+*   Checks for ADK and MDT prerequisites.
+*   Creates the specified deployment folder and SMB share.
+*   Establishes an MDT PSDrive for the new share.
+*   Cleans out default VBScripts and some XML files from a standard MDT share.
+*   Copies PSD scripts, modules, templates, and resources into the appropriate folders within the new deployment share (`Scripts`, `Tools\Modules`, `Templates`, `PSDResources`).
+*   Sets default PSD-specific properties on the deployment share (e.g., boot image names, background).
+*   Adjusts permissions on the deployment share folder for typical access.
+*   Creates/Copies `Bootstrap.ini` and `CustomSettings.ini` into the `Control` folder (either generated from prompts or copied from `INIFiles` if `-Silent`).
+
+## 4. Post-`Install-PSD.ps1` Configuration (MDT Workbench)
+
+After `Install-PSD.ps1` completes successfully, you need to further populate and configure your deployment share using the MDT Deployment Workbench:
+
+1.  **Open Deployment Workbench:** Launch the MDT Deployment Workbench console.
+2.  **Add/Open Deployment Share:**
+    *   If it's a new share, right-click "Deployment Shares" and select "New Deployment Share." Point it to the physical path you provided to `Install-PSD.ps1` (e.g., `D:\PSDShare`). MDT will recognize it.
+    *   If you upgraded, simply open the existing share.
+3.  **Import Operating Systems:**
+    *   Navigate to the "Operating Systems" node in your deployment share.
+    *   Right-click and select "Import Operating System." Follow the wizard to import your OS WIM files (custom images or full source files).
+4.  **Import Applications (Optional):**
+    *   Navigate to the "Applications" node.
+    *   Right-click and select "New Application." Follow the wizard to add applications you want to deploy. PSD's `PSDApplications.ps1` will rely on these MDT application objects.
+5.  **Import Drivers (Optional but Recommended):**
+    *   Navigate to the "Out-of-Box Drivers" node.
+    *   Create a folder structure that makes sense for your driver management (e.g., by Make/Model/OS).
+    *   Right-click the appropriate folder and select "Import Drivers." Follow the wizard to import your driver source files.
+6.  **Review Deployment Share Properties:**
+    *   Right-click your deployment share in the Workbench and select "Properties."
+    *   Review settings on tabs like "Rules" (which shows `CustomSettings.ini` and `Bootstrap.ini`), "Windows PE" (for boot image settings, drivers, features), and "Monitoring" (if you plan to use MDT monitoring). `Install-PSD.ps1` sets some PE defaults like the branding image.
+
+## 5. Next Steps
+
+Once your deployment share is created by `Install-PSD.ps1` and populated with your OS, applications, and drivers:
+
+*   **Create a Task Sequence:** Refer to the `PSD_TaskSequence_Guide.md` for detailed instructions on building a task sequence that utilizes the PSD scripts.
+*   **Update Boot Images:** After configuring task sequences and potentially adding drivers to WinPE in the Workbench, update your Lite Touch Boot Images.
+*   **Test Deployment:** Thoroughly test your deployments to a test client machine.
+
+This guide should help you get PSD installed and configured. Refer to other documents in this `Documentation` folder for more specific guidance on task sequences and other PSD features.

--- a/Documentation/PSD_TaskSequence_Guide.md
+++ b/Documentation/PSD_TaskSequence_Guide.md
@@ -1,0 +1,119 @@
+# PowerShell Deployment (PSD) Task Sequence Guide
+
+This guide outlines a standard task sequence structure for operating system deployment using the PowerShell Deployment (PSD) framework. This task sequence can be created and customized within the Microsoft Deployment Toolkit (MDT) Workbench.
+
+## General Recommendations
+
+*   **MDT Workbench:** Use the MDT Workbench to create your task sequence.
+*   **"Run PowerShell Script" Steps:** Most PSD steps will be implemented using MDT's "Run PowerShell Script" task sequence step type.
+*   **Script Location:** Ensure your PSD scripts (from the deployment share's `Scripts` folder) are correctly referenced in each step (e.g., using `%SCRIPTROOT%\YourPSDScript.ps1`).
+*   **Error Handling:** For critical PSD script steps, ensure the "Continue on error" checkbox is **unchecked** on the "Options" tab of the task sequence step. This will cause the task sequence to fail if the script encounters a terminating error.
+*   **Task Sequence Variables:** PSD scripts heavily rely on MDT/PSD Task Sequence Variables for configuration and state management. Many of these are set by `PSDGather.ps1` or defined in `CustomSettings.ini`.
+
+## Task Sequence Structure
+
+The following is a recommended structure, organized by phase:
+
+### 1. Preinstall Phase
+
+This phase prepares the system for OS installation, running in Windows PE.
+
+*   **(Optional) Pre-Preinstall Group:**
+    *   Conditional steps for BIOS/UEFI configuration, firmware updates, etc. (Often hardware-specific, may use vendor tools).
+
+*   **Gather & Validate Group:**
+    *   **Step: Gather (Initial)**
+        *   **Script:** `PSDGather.ps1`
+        *   **Purpose:** Collects initial hardware/software information and processes `CustomSettings.ini` to populate Task Sequence Variables.
+        *   **Key Variables Used:** Reads `CustomSettings.ini`, `Bootstrap.ini`.
+        *   **Key Variables Set:** Many, including `IsUEFI`, `AssetTag`, `Make`, `Model`, `OSDComputerName` (potential initial value), `DeployRoot`, `SLShare`, etc.
+    *   **Step: Validate Deployment Readiness**
+        *   **Script:** `PSDValidate.ps1`
+        *   **Purpose:** Checks system readiness based on rules defined by `PSDReadinessScript` and `PSDReadinessCheck` variables (from `CustomSettings.ini`). Examples: UEFI, TPM, ADDS connectivity, disk space.
+        *   **Key Variables Used:** `PSDReadinessScript`, `PSDReadinessCheck*`, `PSDReadinessAllowBypass`.
+
+*   **Partition Disk(s) Group:**
+    *   **Step: Format and Partition Disk**
+        *   **Script:** `PSDPartition.ps1`
+        *   **Purpose:** Formats the destination disk and creates necessary partitions (e.g., Boot, OS, Recovery) based on whether the system is BIOS or UEFI.
+        *   **Key Variables Used:** `DestinationDisk`, `IsUEFI`, `WipeDisk`.
+        *   **Key Variables Set:** `OSVolume`, `BootVolume`, `RecoveryVolume` (letters/paths for the created partitions).
+
+*   **(Optional) Pre-OS Apply Custom Tasks Group:**
+    *   User-defined steps, e.g., running `PSDPrestart.ps1` if it performs actions beyond just displaying a UI (which might be called by `PSDGather.ps1` or `PSDValidate.ps1` if it's a wizard).
+
+### 2. Install Operating System Phase
+
+This phase applies the OS image and configures it. Continues in Windows PE.
+
+*   **Step: Apply Operating System Image**
+    *   **Script:** `PSDApplyOS.ps1`
+    *   **Purpose:** Applies the WIM image to the target OS volume.
+    *   **Key Variables Used:** `OSGUID` (from MDT Workbench OS selection), `DestinationDisk`, `DestinationPartition` (less common, `OSVolume` is preferred), `OSVolume` (target for OS).
+*   **Step: Apply Unattend.xml Configuration**
+    *   **Script:** `PSDConfigure.ps1`
+    *   **Purpose:** Modifies the `unattend.xml` file (associated with the Task Sequence in MDT) with dynamic values from Task Sequence Variables, then applies it to the offline OS image.
+    *   **Key Variables Used:** Many variables from `CustomSettings.ini` (e.g., `AdminPassword`, `TimeZone`, `JoinDomain`, `ComputerName`). Uses `ZTIConfigure.xml` as a mapping file.
+    *   **Key Variables Set:** Potentially updates some TS vars if ZTIConfigure rules dictate.
+*   **Step: Inject Drivers**
+    *   **Script:** `PSDDrivers.ps1`
+    *   **Purpose:** Injects necessary drivers into the offline OS image based on make/model or selection profiles.
+    *   **Key Variables Used:** `DriverSelectionProfile` (e.g., "All Drivers", or a specific profile), `DriverGroup001` (for specific driver paths), `OSVersion`, `OSArchitecture`.
+
+### 3. Postinstall Phase (Full OS)
+
+This phase runs after the first boot into the newly installed operating system.
+
+*   **Initial Setup Group:**
+    *   *Note: The transition from WinPE to Full OS is handled by Setup. `PSDStart.ps1` is often configured via `SetupComplete.cmd` or an equivalent mechanism to run on first boot, copy necessary PSD files to the full OS (e.g., C:\MININT), and then resume the task sequence.*
+    *   **Step: Gather (Full OS)**
+        *   **Script:** `PSDGather.ps1`
+        *   **Purpose:** Refreshes Task Sequence Variables, now running in the context of the full OS.
+        *   **Key Variables Used:** `CustomSettings.ini`, `Bootstrap.ini`.
+*   **System Configuration Group:**
+    *   **(Optional) Step: Install Roles and Features**
+        *   **Script:** `PSDRoleInstall.ps1`
+        *   **Purpose:** Installs Windows roles and features specified by Task Sequence Variables (e.g., `OSRoles`, `OSRoleServices`, `OSFeatures`).
+        *   **Key Variables Used:** `OSRoles`, `OSRoleServices`, `OSFeatures`.
+    *   **(Optional) Step: Windows Update (Pre-Applications)**
+        *   **Script:** `PSDWindowsUpdate.ps1`
+        *   **Purpose:** Scans for and installs Windows Updates.
+        *   **Key Variables Used:** `WUServer` (optional WSUS server).
+*   **Application Installation Group:**
+    *   **Step: Install Applications**
+        *   **Script:** `PSDApplications.ps1`
+        *   **Purpose:** Orchestrates the installation of multiple applications. This script typically calls other, individual application installation scripts.
+        *   **Key Variables Used:** `Applications` (from MDT database or `CustomSettings.ini` defining which apps to install).
+*   **System Customization & Final Updates Group:**
+    *   **(Optional) Step: Windows Update (Post-Applications)**
+        *   **Script:** `PSDWindowsUpdate.ps1`
+        *   **Purpose:** Another pass for updates after applications are installed.
+    *   **(Optional) Step: Apply Computer Name (if not set by Unattend.xml or earlier)**
+        *   **Script:** `PSDSetVariable.ps1` (to set `OSDComputerName`) followed by a script/command to apply it if deferred. Or rely on `PSDTattoo.ps1`.
+    *   **Step: Apply Branding/Tattoo**
+        *   **Script:** `PSDTattoo.ps1`
+        *   **Purpose:** Applies OEM information, sets registry keys for support info, potentially sets computer name if not already done.
+        *   **Key Variables Used:** `AssetTag`, `SerialNumber`, `Make`, `Model`, `OSDComputerName`.
+
+### 4. State Restore & Finalization Phase
+
+This phase handles final cleanup, log copying, and user state restoration if applicable.
+
+*   **(Optional) User State Restore Group:**
+    *   Standard MDT USMT "Restore User State" steps would go here if USMT was used in a refresh scenario.
+*   **Finalization Group:**
+    *   **(Optional) Step: Restart Computer** (Standard MDT step, if needed before final cleanup).
+    *   **Step: Gather (Final Log Collection)**
+        *   **Script:** `PSDGather.ps1`
+        *   **Purpose:** Final gather to ensure all latest variable states are logged.
+    *   **Step: Copy Logs**
+        *   **Script:** `PSDCopyLogs.ps1`
+        *   **Purpose:** Collects all relevant logs (including `ZTIGather.xml` from the log path) and copies them to the `SLShare`.
+        *   **Key Variables Used:** `SLShare`, `LogUserDomain`, `LogUserID`, `LogUserPassword`.
+    *   **(Optional) Step: Final Custom Tasks** (User-defined cleanup or notification scripts).
+    *   **Step: Final Actions (Cleanup & Reboot/Shutdown)**
+        *   **Script:** `PSDFinal.ps1`
+        *   **Purpose:** Performs final cleanup (e.g., removes MININT folder, clears autologon), and then executes the `FinishAction` (e.g., REBOOT, SHUTDOWN) defined in `CustomSettings.ini`.
+        *   **Key Variables Used:** `FinishAction`.
+
+This guide provides a robust template. Remember to customize it based on your specific deployment needs and the features of PSD you intend to use.

--- a/INIFiles/Bootstrap.ini
+++ b/INIFiles/Bootstrap.ini
@@ -1,21 +1,17 @@
 [Settings]
-Priority=PSDRoots,Default
+Priority=Default
 Properties=
 
-[PSDRoots]
-PSDDeployRoots=https://mdt01.corp.viamonstra.com/mdtproduction
-;UserDomain=MDT01
-;UserID=MDT_BA
-;UserPassword=P@ssw0rd
-
 [Default]
-SkipBDDWelcome=NO
-;PSDPrestartMode=FullScreen
-;PSDPrestartMode=Native
-PSDPrestartMode=PrestartMenu
-PSDDebug=NO
+; DeployRoot: THIS WILL BE SET BY Install-PSD.ps1 IF RUN INTERACTIVELY.
+; FOR SILENT INSTALLS, ENSURE YOUR TASK SEQUENCE OR OTHER MECHANISMS SET DeployRoot,
+; OR MANUALLY EDIT THIS FILE POST-INSTALL IF NEEDED.
+; Example: DeployRoot=\\$TaskSequenceServer\DeploymentShare$
+; UserID=
+; UserDomain=
+; UserPassword=
 
-;PSDPrestartPosition=HorizontalTop
-;PSDPrestartPosition=VerticalLeft
-PSDPrestartPosition=VerticalRight
-;PSDPrestartPosition=HorizontalBottom
+SkipBDDWelcome=YES
+PSDPrestartMode=Native
+PSDDebug=NO
+;PSDPrestartPosition=VerticalRight

--- a/INIFiles/CustomSettings.ini
+++ b/INIFiles/CustomSettings.ini
@@ -1,57 +1,60 @@
 [Settings]
 Priority=Default
-Properties=
+Properties=MyCustomProperty
 
 [Default]
 OSInstall=Y
-_SMSTSORGNAME=ViaMonstra
-_SMSTSPackageName=PC soon to be in service near you
-;LogUserDomain=MDT01
-;LogUserID=PSD_LOG
-;LogUserPassword=P@ssword
-SLSHARE=https://mdt01.corp.viamonstra.com/PSDProductionLog
-TimeZoneName=Pacific Standard Time
-JoinWorkgroup=WORKGROUP
+_SMSTSORGNAME=PSD Deployment Installation
+_SMSTSPackageName=OS Deployment
+
+; AdminPassword: THIS WILL BE SET BY Install-PSD.ps1 IF RUN INTERACTIVELY.
+; FOR SILENT INSTALLS, ENSURE IT IS SET VIA UNATTEND.XML OR OTHER MEANS IF REQUIRED.
+
+; TimeZoneName: THIS WILL BE SET BY Install-PSD.ps1 IF RUN INTERACTIVELY.
+; FOR SILENT INSTALLS, THE OS DEFAULT OR UNATTEND.XML VALUE WILL BE USED.
+; Example: TimeZoneName=Pacific Standard Time
+
 KeyboardLocale=en-US
 UILanguage=en-US
-SystemLocale=en-US
-SkipFinalSummary=NO
-FinishAction=NONE
+UserLocale=en-US
+
+; --- Default Skip Settings for a SILENT Install-PSD.ps1 run ---
+; These can be overridden by values set during interactive install,
+; or by manually editing this file after a silent install.
+SkipAdminPassword=YES
+SkipProductKey=YES
+SkipComputerName=YES
+SkipDomainMembership=YES
+SkipUserData=YES
+SkipLocaleSelection=YES
+SkipTimeZone=YES
+SkipApplications=YES
+SkipAppsOnUpgrade=YES
+SkipBitLocker=YES
+SkipSummary=YES
+SkipFinalSummary=YES
+
+FinishAction=REBOOT
 HideShell=NO
 
 PSDWizard=PSDWizardNew
 ;PSDWizardTheme=Dark
-PSDWizardCustomPaneAllowBypass=YES
-
 SkipPSDWizardSplashScreen=NO
-SkipComputerName=NO
 
-SkipDomainMemberShip=NO
-DomainOUs001=OU=Workstations,OU=ViaMonstra,DC=corp,DC=viamonstra,DC=com
-DomainOUs002=OU=Servers,OU=ViaMonstra,DC=corp,DC=viamonstra,DC=com
+; SLSHARE: Configure this for log collection.
+; Example: SLSHARE=\\$TaskSequenceServer\Logs$
+; LogUserDomain=
+; LogUserID=
+; LogUserPassword=
 
-SkipReadinessCheck=NO
-PSDReadinessAllowBypass=YES
-PSDReadinessScript=Computer_Readiness.ps1
-PSDReadinessCheck001=Test-UEFI
-PSDReadinessCheck002=Test-TPM
-PSDReadinessCheck003=Test-ADDS
-PSDReadinessCheck004=Test-Intune
+; --- Sections for specific features - configure if needed ---
+; JoinWorkgroup=WORKGROUP
+; JoinDomain=YourDomain.com
+; DomainAdmin=YourDomain\AdminUser
+; DomainAdminPassword=SetPassword
+; DomainOUs001=OU=Computers,DC=YourDomain,DC=com
 
-SkipIntuneGroup=NO
-IntuneGroupAllowBypass=YES
-IntuneGroup001=Win - Windows Autupilot - D - User-Driven
-IntuneGroup002=Win - WUFB - D - Delivery Optimization
-IntuneGroup003=Win - WUFB - D - Software Updates Pilot
-IntuneGroup004=Win - WUFB - D - Software Updates Production
-IntuneGroup005=Win - Windows Autopatch - D - Enrollment
-
-SkipRoleSelection=NO
-DeviceRoleAllowBypass=YES
-DeviceRole001=Standard User Device
-DeviceRole002=Priviledged Access Workstation
-DeviceRole003=Developer Workstation
-DeviceRole004=Managers Device
-DeviceRole005=Application Packager Device
-
-;AdminPassword=P@ssw0rd
+; PSDReadinessScript=Computer_Readiness.ps1
+; PSDReadinessCheck001=Test-UEFI
+; SkipReadinessCheck=NO
+; PSDReadinessAllowBypass=YES

--- a/README.md
+++ b/README.md
@@ -1,204 +1,51 @@
-# PowerShell Deployment & Configuration Task Sequence
+# PowerShell Deployment (PSD)
 
-## 1. Overview
+## Overview
 
-This suite of PowerShell scripts provides a framework for automating a sequence of common system deployment and configuration tasks. The main script, `Run-TaskSequence.ps1`, can orchestrate the execution of individual scripts. However, for integration with deployment solutions like Microsoft Deployment Toolkit (MDT), it is generally recommended to call each script as an individual task sequence step. This allows for more granular control and easier parameter passing using MDT variables.
+PowerShell Deployment (PSD) is a suite of scripts and tools designed to enhance and extend the capabilities of Microsoft Deployment Toolkit (MDT) by leveraging the power and flexibility of PowerShell for operating system deployment and configuration. It aims to provide a more modern, script-centric approach to many common deployment tasks, allowing for greater customization and automation.
 
-## 2. Scripts Included
+This project is ideal for IT professionals and deployment engineers looking to:
+*   Automate OS deployment beyond standard MDT capabilities.
+*   Integrate custom PowerShell scripts seamlessly into their deployment process.
+*   Utilize PowerShell-driven wizards and configuration gathering.
+*   Maintain a high degree of control over each step of the task sequence.
 
-The following PowerShell scripts are part of this collection:
+## Key Features
 
-*   **`Run-TaskSequence.ps1`**:
-    *   **Purpose:** The main orchestrator script. It can run other scripts in a predefined order. When doing so, sub-scripts will use their internal default parameter values, or fail if a mandatory parameter is missing (e.g., `Set-DesktopWallpaper.ps1`).
-*   **`Hide-DOAdmin.ps1`**:
-    *   **Purpose:** Modifies the registry to hide a specified user account from the Windows lock/login screen.
-    *   **Parameters:** `-UserNameToHide` (Default: "DOAdmin")
-*   **`Install-Applications.ps1`**:
-    *   **Purpose:** A framework script for installing multiple applications. It iterates through a list of subordinate application installation scripts.
-    *   Includes placeholder scripts: `Install-App1.ps1` and `Install-App2.ps1`. You need to customize these or add new ones for actual application installations.
-*   **`Enable-TipbandVisibility.ps1`**:
-    *   **Purpose:** Modifies the registry to enable the "Tipband Visibility" feature, which affects how taskbar buttons are grouped by setting `TaskbarGlomLevel` to `1`. (No parameters)
-*   **`Set-ChromeAsDefault.ps1`**:
-    *   **Purpose:** Attempts to set Google Chrome as the default web browser by modifying registry settings for HTTP and HTTPS protocols. (No parameters)
-*   **`Set-DesktopWallpaper.ps1`**:
-    *   **Purpose:** Sets the desktop wallpaper for the current user and attempts to set it for the Default User profile (affecting new user accounts).
-    *   **Parameters:**
-        *   `-WallpaperPath` (Mandatory, String): Full path to the wallpaper image file.
-        *   `-WallpaperStyle` (Optional, String, Default: "2" - Stretch): Style like '0' (Center), '2' (Stretch), '6' (Fit), '10' (Fill).
-        *   `-TileWallpaper` (Optional, String, Default: "0" - No Tile): '0' or '1'.
-*   **`Install-Drivers.ps1`**:
-    *   **Purpose:** Provides a framework for installing multiple drivers from `.inf` files located in a specified directory. It uses `pnputil.exe` for driver installation.
-    *   **Parameters:** `-DriverSourcePath` (Default: ".\Drivers")
-*   **`Copy-DOTempFolder.ps1`**:
-    *   **Purpose:** Copies a folder from a specified network deployment server or share to a local path on the target machine.
-    *   **Parameters:**
-        *   `-SourcePath` (Default: "\\DeploymentServer\Share\DO-Temp")
-        *   `-DestinationPath` (Default: "C:\DO-Temp")
+*   **PowerShell-Driven Task Sequences:** Execute most deployment tasks using PowerShell scripts and modules.
+*   **Customizable Gather Logic:** `PSDGather.ps1` provides extensive information gathering, easily extended with custom variables and rules.
+*   **Interactive Wizards:** Modern WPF-based wizards (`PSDWizardNew`) for prestart interaction in WinPE.
+*   **Modular Design:** Core functionalities are encapsulated in PowerShell modules for better organization and reusability.
+*   **Extensible:** Easily add your own custom scripts and integrate them into the PSD framework.
+*   **MDT Integration:** Designed to work within the Microsoft Deployment Toolkit environment, leveraging its structure for deployment shares, task sequences, and monitoring.
 
-## 3. Prerequisites
+## Getting Started
 
-*   **PowerShell:** These scripts are generally compatible with PowerShell 5.1 and later.
-*   **Administrator Privileges:** Scripts performing system-wide changes (`Run-TaskSequence.ps1`, `Hide-DOAdmin.ps1`, `Install-Drivers.ps1`, `Set-DesktopWallpaper.ps1`) **must** be run with Administrator privileges.
-*   **Google Chrome:** For `Set-ChromeAsDefault.ps1` to function, Google Chrome must be installed.
-*   **Driver Files:** For `Install-Drivers.ps1`, driver packages must be in the directory specified by `-DriverSourcePath`.
-*   **Deployment Server Access:** For `Copy-DOTempFolder.ps1`, the `-SourcePath` must be accessible.
-*   **Application Installers:** For `Install-Applications.ps1`, actual application installation scripts must be created and listed correctly.
-*   **Wallpaper Image:** For `Set-DesktopWallpaper.ps1`, a valid image file must be provided via the `-WallpaperPath` parameter.
+To get started with PowerShell Deployment:
 
-## 4. Setup & Configuration
+1.  **Prerequisites:** Ensure you have the necessary versions of Windows ADK (including WinPE Add-on) and Microsoft Deployment Toolkit (MDT) installed on your deployment server.
+2.  **Installation:** For detailed instructions on setting up a PSD-enabled deployment share, please see the:
+    *   **[Installation Guide](./Documentation/InstallationGuide.md)**
+3.  **Task Sequence Creation:** Once PSD is installed and your deployment share is populated (OS, drivers, applications), refer to the following guide to create your deployment task sequence:
+    *   **[Task Sequence Guide](./Documentation/PSD_TaskSequence_Guide.md)**
 
-1.  **Placement:** All `.ps1` script files should generally be placed in the same directory, especially if using `Run-TaskSequence.ps1` or if scripts call each other using relative paths. For MDT, this would be your script package source directory.
-2.  **Script-Specific Configuration (Defaults & Parameters):**
-    *   Many scripts now use parameters for key paths or settings. These have default values defined within the scripts.
-    *   **`Hide-DOAdmin.ps1`:** `-UserNameToHide` (default: "DOAdmin").
-    *   **`Install-Drivers.ps1`:** `-DriverSourcePath` (default: ".\Drivers"). Ensure this path contains your driver INF files and packages.
-    *   **`Copy-DOTempFolder.ps1`:** `-SourcePath` (default: "\\DeploymentServer\Share\DO-Temp") and `-DestinationPath` (default: "C:\DO-Temp").
-    *   **`Set-DesktopWallpaper.ps1`:** `-WallpaperPath` is mandatory. `-WallpaperStyle` (default: "2") and `-TileWallpaper` (default: "0") can be adjusted.
-    *   **`Install-Applications.ps1`:** Edit the `$applicationInstallScripts` array internally to list your custom application installation scripts (e.g., `".\Install-Office365.ps1"`). Create these corresponding `.ps1` files.
-    *   These parameters can be supplied on the command line when running scripts individually, or via MDT Task Sequence variables (see MDT Integration Guide).
+## Project Structure
 
-## 5. Execution
+A brief overview of the key directories in this project:
 
-*   **Individual Scripts:** Each script can be run standalone. Remember to provide any mandatory parameters.
-    *   Example: `.\Set-DesktopWallpaper.ps1 -WallpaperPath "C:\Path\To\Your\Image.jpg"`
-*   **Using `Run-TaskSequence.ps1`:**
-    *   This script runs a predefined sequence of the other scripts.
-    *   It will use the default parameter values defined within each sub-script.
-    *   **Important:** Scripts with mandatory parameters without defaults (like `Set-DesktopWallpaper.ps1 -WallpaperPath`) will fail if `Run-TaskSequence.ps1` calls them without a mechanism to provide these parameters. The orchestrator will log this failure.
-    *   To run:
-        1.  Open PowerShell as Administrator.
-        2.  Navigate to the script directory: `cd C:\Path\To\Your\Scripts`
-        3.  Execute: `.\Run-TaskSequence.ps1`
+*   **`Install-PSD.ps1`**: The main installation script to set up or upgrade a PSD deployment share.
+*   **`Scripts/`**: Contains the core PSD PowerShell scripts (`.ps1`) and modules (`.psm1`) that perform various deployment tasks.
+*   **`Templates/`**: Includes PSD-specific Unattend.xml templates and other template files used by the MDT provider.
+*   **`INIFiles/`**: Default `Bootstrap.ini` and `CustomSettings.ini` files used as a base for silent installations or as a reference.
+*   **`PSDResources/`**: Contains resources like branding images, prestart executables, plugins, and other tools used during deployment.
+*   **`Documentation/`**: Additional guides and documentation for using PSD.
+*   **`Branding/`**: Source files for some of the branding elements.
+*   **`Plugins/`**: Example plugins or extensions for PSD.
 
-## 6. MDT Integration Guide
+## Contributing
 
-While `Run-TaskSequence.ps1` can execute the entire suite, for **Microsoft Deployment Toolkit (MDT)** or **PowerShell Deployment (PSD)**, the recommended best practice is to call each utility script as an individual "Run PowerShell Script" step within your Task Sequence. This approach offers:
+We welcome contributions! Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on how to contribute to this project. (Note: Create `CONTRIBUTING.md` if it doesn't exist and you want to define contribution guidelines).
 
-*   **Granular Control:** Easier to enable/disable specific tasks.
-*   **MDT Logging/Error Handling:** Better visibility of success/failure for each step directly in MDT logs.
-*   **Simplified Parameter Passing:** Leverage MDT Task Sequence variables effectively.
+## License
 
-**General Principles for MDT:**
-
-*   **Script Package:** Create an MDT Package containing all these PowerShell scripts.
-*   **Task Sequence Steps:** For each script you want to run, add a new "Run PowerShell Script" step in your Task Sequence.
-    *   Point the step to the script within your package (e.g., `%SCRIPTROOT%\YourScriptName.ps1` if running from `Deploy\Scripts`, or referencing the package path).
-
-**Passing Parameters via MDT Task Sequence Variables:**
-
-You can set MDT Task Sequence variables (e.g., in `CustomSettings.ini`, the MDT database, or via "Set Task Sequence Variable" steps) and then pass these to your scripts.
-
-*   **Example for `Copy-DOTempFolder.ps1`:**
-    1.  Define MDT variables (e.g., in `CustomSettings.ini` or as TS steps):
-        *   `DOTempSource=\\MyServer\Deployment\Staging\DO-Temp`
-        *   `DOTempDest=C:\Windows\Temp\DO-Temp`
-    2.  In the "Run PowerShell Script" step for `Copy-DOTempFolder.ps1`, set "Parameters":
-        *   `-SourcePath "%DOTempSource%" -DestinationPath "%DOTempDest%"`
-
-*   **Example for `Install-Drivers.ps1`:**
-    1.  MDT often uses `%OSDDriverPath%` or you can define your own like `MyDriverPath`.
-    2.  Parameters: `-DriverSourcePath "%MyDriverPath%"`
-
-*   **Example for `Set-DesktopWallpaper.ps1`:**
-    1.  Define an MDT variable: `OSDWallpaper=\\MyServer\Deployment\Branding\wallpaper.jpg`
-    2.  Parameters: `-WallpaperPath "%OSDWallpaper%"`
-    3.  Optionally add: `-WallpaperStyle "2" -TileWallpaper "0"` if defaults are not desired.
-
-*   **Example for `Hide-DOAdmin.ps1`:**
-    1.  Define an MDT variable: `AccountToHide=LocalAdminAccount`
-    2.  Parameters: `-UserNameToHide "%AccountToHide%"`
-
-**Using `Run-TaskSequence.ps1` in MDT:**
-
-*   If you choose to run `Run-TaskSequence.ps1` as a single step in MDT:
-    *   It will execute its internal sequence.
-    *   Sub-scripts will use their *default* parameter values unless you modify those sub-scripts to directly read MDT environment variables (e.g., using `$env:VariableName`). This is a more advanced customization.
-    *   **Warning:** `Set-DesktopWallpaper.ps1` will likely fail when called by `Run-TaskSequence.ps1` in this way, as its mandatory `-WallpaperPath` parameter won't be supplied by the orchestrator itself. It's better to call `Set-DesktopWallpaper.ps1` as its own MDT step.
-
-## 7. Logging
-
-*   The main `Run-TaskSequence.ps1` script provides console logging for its orchestration steps.
-*   Individual scripts also contain their own `Write-Host`, `Write-Warning`, or `Write-Error` messages.
-*   When run via MDT, script output and errors are typically captured in MDT logs (e.g., `BDD.log`, `SMSTS.log`).
-
-## 8. Customization
-
-*   **Adding/Removing Applications (`Install-Applications.ps1`):**
-    *   Edit the `$applicationInstallScripts` array within `Install-Applications.ps1`.
-    *   Create the corresponding `.ps1` files for silent application installs.
-*   **Modifying Task Sequence (`Run-TaskSequence.ps1`):**
-    *   Edit the `$scriptsToExecute` array in `Run-TaskSequence.ps1` to change the sequence or remove scripts. Be mindful of potential dependencies.
-
-## 9. Disclaimer
-
-*   **Test Thoroughly:** These scripts make significant system changes. Always test thoroughly in a non-production environment before deployment.
-*   **Default Browser Settings:** Programmatically changing default applications (like the browser via `Set-ChromeAsDefault.ps1`) can be unreliable on modern Windows versions. Consider official methods like XML-based default association files for enterprise scenarios.
-*   **Use at Your Own Risk:** The authors/contributors are not responsible for any damage or unintended consequences from using these scripts.## MDT Integration Guide
-
-While `Run-TaskSequence.ps1` can execute the entire suite, for **Microsoft Deployment Toolkit (MDT)** or **PowerShell Deployment (PSD)**, the recommended best practice is to call each utility script as an individual "Run PowerShell Script" step within your Task Sequence. This approach offers:
-
-*   **Granular Control:** Easier to enable/disable specific tasks.
-*   **MDT Logging/Error Handling:** Better visibility of success/failure for each step directly in MDT logs.
-*   **Simplified Parameter Passing:** Leverage MDT Task Sequence variables effectively.
-
-**General Principles for MDT:**
-
-*   **Script Package:** Create an MDT Package containing all these PowerShell scripts. Your scripts will then be accessible during the Task Sequence, typically via a path relative to the script execution location (e.g., using `.` or `%SCRIPTROOT%` if MDT sets the working directory to `Deploy\Scripts`, or a path relative to the package).
-*   **Task Sequence Steps:** For each script you want to run, add a new "Run PowerShell Script" step in your Task Sequence.
-    *   In the "PowerShell script:" field, specify the name of the script, e.g., `YourScriptName.ps1`. If your package is not `Deploy\Scripts`, you might need to use `.\%TaskSequenceID%\YourScriptName.ps1` or similar, assuming your package is named after the Task Sequence ID, or directly reference the package path.
-
-**Passing Parameters via MDT Task Sequence Variables:**
-
-You can set MDT Task Sequence variables (e.g., in `CustomSettings.ini`, the MDT database, or via "Set Task Sequence Variable" steps during the Task Sequence) and then pass these to your scripts as parameters.
-
-*   **Example for `Copy-DOTempFolder.ps1`:**
-    1.  Define MDT variables (e.g., in `CustomSettings.ini` or as separate "Set Task Sequence Variable" steps):
-        *   `DOTempSource=\\MyFileServer\DeploymentShare\Staging\DO-Temp`
-        *   `DOTempDest=C:\Windows\Temp\DO-TempFromMDT`
-    2.  In the "Run PowerShell Script" step for `Copy-DOTempFolder.ps1`, under the "Parameters" field, specify:
-        *   `-SourcePath "%DOTempSource%" -DestinationPath "%DOTempDest%"`
-
-*   **Example for `Install-Drivers.ps1`:**
-    1.  MDT automatically populates `%OSDDriverPath%` during the "Inject Drivers" phase if you're using MDT's driver handling. Alternatively, you can define your own variable like `MyModelSpecificDriverPath`.
-    2.  Parameters: `-DriverSourcePath "%OSDDriverPath%"` or `-DriverSourcePath "%MyModelSpecificDriverPath%"`
-
-*   **Example for `Set-DesktopWallpaper.ps1`:**
-    1.  Define an MDT variable for the wallpaper path (ensure the client can access this path during the TS):
-        *   `OSDWallpaperPath=\\MyFileServer\DeploymentShare\Branding\OurCompanyWallpaper.jpg`
-    2.  Parameters: `-WallpaperPath "%OSDWallpaperPath%"`
-    3.  You can also specify other optional parameters: `-WallpaperStyle "2" -TileWallpaper "0"`
-
-*   **Example for `Hide-DOAdmin.ps1`:**
-    1.  Define an MDT variable for the account name:
-        *   `AccountToHideFromLogin=ServiceAccount01`
-    2.  Parameters: `-UserNameToHide "%AccountToHideFromLogin%"`
-
-**Using `Run-TaskSequence.ps1` in MDT:**
-
-*   If you choose to run `Run-TaskSequence.ps1` as a single step in MDT:
-    *   It will execute its internal sequence of scripts.
-    *   The sub-scripts will use their *default* parameter values as defined within them.
-    *   To pass custom values, you would need to modify `Run-TaskSequence.ps1` or the sub-scripts to directly read MDT environment variables (e.g., using `$env:VariableName` which MDT makes available from Task Sequence variables). This is a more advanced customization not covered by default.
-    *   **Warning:** `Set-DesktopWallpaper.ps1`, when called by `Run-TaskSequence.ps1`, will likely fail. This is because `Set-DesktopWallpaper.ps1` has a mandatory `-WallpaperPath` parameter, and `Run-TaskSequence.ps1` itself does not provide a mechanism to pass this specific parameter down to it. It's strongly recommended to call `Set-DesktopWallpaper.ps1` as its own MDT step with the `-WallpaperPath` parameter explicitly provided.
-
-## 7. Logging
-
-*   The main `Run-TaskSequence.ps1` script provides console logging for its orchestration steps when run manually.
-*   Individual scripts also contain their own `Write-Host`, `Write-Warning`, or `Write-Error` messages for more detailed feedback.
-*   When these scripts are run as steps within an MDT Task Sequence, their output (standard output and error streams) is typically captured in the MDT log files (such as `BDD.log`, and detailed execution in `SMSTS.log` under the `ZTIProcessScript.log` or similar for ZTI PowerShell steps). Review these logs for troubleshooting.
-
-## 8. Customization
-
-*   **Adding/Removing Applications (`Install-Applications.ps1`):**
-    1.  Open `Install-Applications.ps1` in a PowerShell editor.
-    2.  Modify the `$applicationInstallScripts` array to include the relative paths to your actual application installation scripts (e.g., `".\Install-Office365.ps1"`, `".\Install-VSCode.ps1"`).
-    3.  Create these corresponding `.ps1` files in the same directory (your MDT script package). These scripts should contain the silent installation commands for each specific application.
-    4.  The provided `Install-App1.ps1` and `Install-App2.ps1` are non-functional placeholders and should be replaced or removed.
-*   **Modifying Task Sequence (`Run-TaskSequence.ps1`):**
-    *   If using `Run-TaskSequence.ps1` directly, you can change the order of execution or remove scripts from the sequence by editing the `$scriptsToExecute` array. However, be mindful of dependencies. (This is less relevant if following the MDT best practice of individual steps).
-
-## 9. Disclaimer
-
-*   **Test Thoroughly:** These scripts make significant changes to system configuration, including registry modifications and software installations. Always test this entire task sequence and each script in a non-production, isolated lab environment or on a virtual machine before deploying to live systems.
-*   **Default Browser Settings:** Programmatically changing default application associations (like the default web browser with `Set-ChromeAsDefault.ps1`) has become less reliable on modern Windows versions (Windows 10 and later) due to security measures designed to protect user choice. While the script attempts a common method, it may not always work as expected. For robust enterprise solutions, consider using Microsoft's official methods involving XML-based default association files (e.g., via `Dism.exe /Online /Export-DefaultAppAssociations:"C:\AppAssoc.xml"` and `Dism.exe /Online /Import-DefaultAppAssociations:"C:\AppAssoc.xml"`).
-*   **Use at Your Own Risk:** The authors or contributors are not responsible for any damage or unintended consequences that may arise from the use of these scripts. Ensure you understand what each script does before deploying it.
+This project is licensed under the terms of the [LICENSE](./LICENSE) file. (Note: Ensure `LICENSE` file exists).

--- a/Scripts/Copy-ZTIGatherCustom.ps1
+++ b/Scripts/Copy-ZTIGatherCustom.ps1
@@ -1,0 +1,49 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$MinintPath,
+
+    [Parameter(Mandatory=$true)]
+    [string]$DestinationPath
+)
+
+# Attempt to find ZTIGather.xml
+$ztigatherFile = Get-ChildItem -Path $MinintPath -Recurse -Filter "ZTIGather.xml" -File -ErrorAction SilentlyContinue | Select-Object -First 1
+
+if ($null -ne $ztigatherFile) {
+    try {
+        # Try to use Write-PSDLog if available (it might be if called from PSDUtility context)
+        Write-PSDLog -Message "Copy-ZTIGatherCustom: Found ZTIGather.xml at $($ztigatherFile.FullName). Copying to $DestinationPath." -Source "Copy-ZTIGatherCustom"
+    }
+    catch {
+        # Fallback to Write-Host if Write-PSDLog is not available or fails
+        Write-Host "Copy-ZTIGatherCustom: Found ZTIGather.xml at $($ztigatherFile.FullName). Copying to $DestinationPath."
+    }
+
+    try {
+        Copy-Item -Path $ztigatherFile.FullName -Destination $DestinationPath -Force -ErrorAction Stop
+        try {
+            Write-PSDLog -Message "Copy-ZTIGatherCustom: Successfully copied ZTIGather.xml to $DestinationPath." -Source "Copy-ZTIGatherCustom"
+        }
+        catch {
+            Write-Host "Copy-ZTIGatherCustom: Successfully copied ZTIGather.xml to $DestinationPath."
+        }
+    }
+    catch {
+        $errorMessage = $_.Exception.Message
+        try {
+            Write-PSDLog -Message "Copy-ZTIGatherCustom: Error copying ZTIGather.xml to $DestinationPath. Error: $errorMessage" -Source "Copy-ZTIGatherCustom" -LogLevel 3
+        }
+        catch {
+            Write-Host "Copy-ZTIGatherCustom: Error copying ZTIGather.xml to $DestinationPath. Error: $errorMessage"
+        }
+    }
+}
+else {
+    try {
+        Write-PSDLog -Message "Copy-ZTIGatherCustom: ZTIGather.xml not found in $MinintPath." -Source "Copy-ZTIGatherCustom" -LogLevel 2
+    }
+    catch {
+        Write-Host "Copy-ZTIGatherCustom: ZTIGather.xml not found in $MinintPath."
+    }
+}

--- a/Scripts/PSDGather.ps1
+++ b/Scripts/PSDGather.ps1
@@ -66,6 +66,27 @@ switch ($tsenv:GatherLocalOnly)
         $mappingFile = Find-PSDFile -FileName ZTIGather.xml
         Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Processing CustomSettings.ini"
         Invoke-PSDRules -FilePath "$control\CustomSettings.ini" -MappingFile $mappingFile
+
+        # Copy ZTIGather.xml to the LogPath for inclusion in copied logs
+        if ($null -ne $mappingFile -and (Test-Path $mappingFile)) {
+            # Ensure LogPath directory exists (it should have been created by PSDGather.ps1 already or by logger)
+            if (-not (Test-Path $TSEnv:LogPath)) {
+                New-Item -ItemType Directory -Path $TSEnv:LogPath -Force -ErrorAction SilentlyContinue | Out-Null
+            }
+
+            $destinationFile = Join-Path -Path $TSEnv:LogPath -ChildPath "ZTIGather.xml"
+            Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Attempting to copy $mappingFile to $destinationFile"
+            try {
+                Copy-Item -Path $mappingFile -Destination $destinationFile -Force -ErrorAction Stop
+                Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): Successfully copied ZTIGather.xml from $mappingFile to $destinationFile"
+            }
+            catch {
+                Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): ERROR - Failed to copy ZTIGather.xml from $mappingFile to $destinationFile. Error: $($_.Exception.Message)" -LogLevel 3
+            }
+        }
+        else {
+            Write-PSDLog -Message "$($MyInvocation.MyCommand.Name): ZTIGather.xml path ($mappingFile) is null or file does not exist. Skipping copy to LogPath." -LogLevel 2
+        }
     }
 }
 


### PR DESCRIPTION
The ZTIGather.xml file was not being copied to the SLShare at the end of the deployment process.

This commit modifies `Scripts/PSDGather.ps1` to address this:
- After `ZTIGather.xml` is processed by `Invoke-PSDRules`, the script now copies the `ZTIGather.xml` file (referenced by the `$mappingFile` variable) to the directory specified by `$TSEnv:LogPath`.
- This ensures that when `PSDCopyLogs.ps1` (or a utility calling it like `Clear-PSDInformation`) archives and uploads logs from `$TSEnv:LogPath` (typically `MININT\SMSOSD\OSDLOGS`), `ZTIGather.xml` is included.

This change ensures that `ZTIGather.xml` is available on the share for logging, auditing, and debugging purposes, and that its primary functionality within the PSD gather process remains unaffected. The syntax used is compliant with PowerShell Deployment (PSD) standards.